### PR TITLE
Logging for LiveProfiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ docs/version.entities
 cscope.files
 cscope.out
 gstshark_*-*-*_*:*:*/
+.vscode
 
 # Git conflicts
 *.c.orig

--- a/plugins/tracers/gstctf.c
+++ b/plugins/tracers/gstctf.c
@@ -700,6 +700,21 @@ add_metadata_event_struct (const gchar * metadata_event)
   g_mutex_unlock (&ctf_descriptor->mutex);
 }
 
+void
+do_print_log (const char *filename, const char *text)
+{
+  /* Lock mem, datastream and output_stream resources */
+  g_mutex_lock (&ctf_descriptor->mutex);
+
+  gchar *log_path =
+      g_strjoin (G_DIR_SEPARATOR_S, ctf_descriptor->dir_name, filename, NULL);
+
+  FILE *fp = g_fopen (log_path, "a");
+  fprintf (fp, "%s\n", text);
+  fclose (fp);
+
+  g_mutex_unlock (&ctf_descriptor->mutex);
+}
 
 void
 do_print_cpuusage_event (event_id id, guint32 cpu_num, gfloat * cpuload)

--- a/plugins/tracers/gstctf.h
+++ b/plugins/tracers/gstctf.h
@@ -55,5 +55,7 @@ void do_print_buffer_event (event_id id, const gchar * pad, GstClockTime pts,
     guint64 offset_end, guint64 size, GstBufferFlags flags,
     guint32 refcount);
 void do_print_ctf_init (event_id id);
+void do_print_log(const char* filename, const char* text);
+
 G_END_DECLS
 #endif /*__GST_CTF_H__*/

--- a/plugins/tracers/gstliveprofiler.c
+++ b/plugins/tracers/gstliveprofiler.c
@@ -68,11 +68,14 @@ void
 generate_meta_data_pad (gpointer key, gpointer value, gpointer user_data)
 {
   gchar *pad_name = (gchar *) key;
+  PadUnit *data = (PadUnit *) value;
   gchar *element_name = (gchar *) user_data;
 
+  data->elem_idx = log_idx;
   char text[50];
-  sprintf (text, "%d %s-%s", log_idx++, element_name, pad_name);
+  sprintf (text, "%d %s-%s", log_idx, element_name, pad_name);
   do_print_log ("log_metadata", text);
+  log_idx++;
 }
 
 void
@@ -80,6 +83,8 @@ generate_meta_data (gpointer key, gpointer value, gpointer user_data)
 {
   gchar *name = (gchar *) key;
   ElementUnit *data = (ElementUnit *) value;
+
+  data->elem_idx = log_idx;
 
   char text[50];
   sprintf (text, "%d %s", log_idx++, name);

--- a/plugins/tracers/gstliveprofiler.c
+++ b/plugins/tracers/gstliveprofiler.c
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdio.h>
 
 #include "gstliveprofiler.h"
 #include "gstliveunit.h"

--- a/plugins/tracers/gstliveprofiler.c
+++ b/plugins/tracers/gstliveprofiler.c
@@ -9,214 +9,247 @@
 #include "gstliveprofiler.h"
 #include "gstliveunit.h"
 #include "visualizeutil.h"
+#include "gstctf.h"
 
 // Plugin Data
-Packet * packet;
+Packet *packet;
+int log_idx = 0;
+int metadata_writed = 0;
 
 gboolean
 is_filter (GstElement * element)
 {
-	GList * pads;
-	GList * iterator;
-	GstPad * pPad;
-	gint sink = 0;
-	gint src = 0;
+  GList *pads;
+  GList *iterator;
+  GstPad *pPad;
+  gint sink = 0;
+  gint src = 0;
 
-	pads = GST_ELEMENT_PADS (element);
-	iterator = g_list_first (pads);
-	while(iterator != NULL) {
-		pPad = iterator->data;
-		if(gst_pad_get_direction(pPad) == GST_PAD_SRC) 
-			src++;
-		if(gst_pad_get_direction(pPad) == GST_PAD_SINK)
-			sink++;
-		if(src > 1 || sink > 1)
-			return FALSE;
+  pads = GST_ELEMENT_PADS (element);
+  iterator = g_list_first (pads);
+  while (iterator != NULL) {
+    pPad = iterator->data;
+    if (gst_pad_get_direction (pPad) == GST_PAD_SRC)
+      src++;
+    if (gst_pad_get_direction (pPad) == GST_PAD_SINK)
+      sink++;
+    if (src > 1 || sink > 1)
+      return FALSE;
 
-		iterator = g_list_next(iterator);
-	}
-	if(src == 1 && sink == 1)
-		return TRUE;
-	else
-		return FALSE;
+    iterator = g_list_next (iterator);
+  }
+  if (src == 1 && sink == 1)
+    return TRUE;
+  else
+    return FALSE;
+}
+
+void
+generate_meta_data_pad (gpointer key, gpointer value, gpointer user_data)
+{
+  gchar *pad_name = (gchar *) key;
+  gchar *element_name = (gchar *) user_data;
+
+  char text[50];
+  sprintf (text, "%d %s-%s", log_idx++, element_name, pad_name);
+  do_print_log ("log_metadata", text);
+}
+
+void
+generate_meta_data (gpointer key, gpointer value, gpointer user_data)
+{
+  gchar *name = (gchar *) key;
+  ElementUnit *data = (ElementUnit *) value;
+
+  char text[50];
+  sprintf (text, "%d %s", log_idx++, name);
+  do_print_log ("log_metadata", text);
+
+  g_hash_table_foreach (data->pad, (GHFunc) generate_meta_data_pad, name);
 }
 
 /*
  * Adds children of element recursively to the Hashtable.
+ * Write log metadata file when LOG_ENABLE is true
  */
 void
 add_children_recursively (GstElement * element, GHashTable * table)
 {
-	GList * children, * iter;
-	ElementUnit * eUnit;
-	PadUnit * pUnit;
+  GList *children, *iter;
+  ElementUnit *eUnit;
+  PadUnit *pUnit;
 
-	if (GST_IS_BIN (element)) {
-		children = GST_BIN_CHILDREN (element);
-		iter = g_list_first (children);
-		
-		while(iter != NULL) {
-			add_children_recursively ((GstElement *) iter->data, table);
-			iter = g_list_next (iter);
-		}
-	}
-	else {
-		eUnit = element_unit_new();
-		eUnit->element = element;
-		eUnit->pad = g_hash_table_new (g_str_hash, g_str_equal);
-		eUnit->is_filter = is_filter(element);
+  if (GST_IS_BIN (element)) {
+    children = GST_BIN_CHILDREN (element);
+    iter = g_list_first (children);
 
-		children = GST_ELEMENT_PADS (element);
-		iter = g_list_first (children);
+    while (iter != NULL) {
+      add_children_recursively ((GstElement *) iter->data, table);
+      // add_log_metadata(GST_OBJECT_NAME (iter->data));
+      iter = g_list_next (iter);
+    }
+  } else {
+    eUnit = element_unit_new ();
+    eUnit->element = element;
+    eUnit->pad = g_hash_table_new (g_str_hash, g_str_equal);
+    eUnit->is_filter = is_filter (element);
 
-		while(iter != NULL) {
-			pUnit = pad_unit_new();
-			pUnit->element = iter->data;
-			g_hash_table_insert(eUnit->pad, GST_OBJECT_NAME (iter->data), pUnit);
-			
-			iter = g_list_next (iter);
-		}
-		g_hash_table_insert(table, GST_OBJECT_NAME (element), eUnit);
-	}
+    children = GST_ELEMENT_PADS (element);
+    iter = g_list_first (children);
+
+    while (iter != NULL) {
+      pUnit = pad_unit_new ();
+      pUnit->element = iter->data;
+      g_hash_table_insert (eUnit->pad, GST_OBJECT_NAME (iter->data), pUnit);
+
+      iter = g_list_next (iter);
+    }
+    g_hash_table_insert (table, GST_OBJECT_NAME (element), eUnit);
+  }
 }
 
 gboolean
-gst_liveprofiler_init (void) 
+gst_liveprofiler_init (void)
 {
-	gint cpu_num;
-	gfloat * cpu_load;
-	GHashTable * elements;
-	GHashTable * connections;
-	
-	cpu_num = get_nprocs();
-	cpu_load = g_malloc0 (sizeof(gfloat) * cpu_num);
-	elements = g_hash_table_new (g_str_hash, g_str_equal);
-	connections = g_hash_table_new (g_str_hash, g_str_equal);
+  gint cpu_num;
+  gfloat *cpu_load;
+  GHashTable *elements;
+  GHashTable *connections;
 
-	packet = g_malloc0 (sizeof(Packet));
-	packet_set_cpu_num (packet, cpu_num);
-	packet_set_cpu_load (packet, cpu_load);
-	packet_set_elements (packet, elements);
-	packet_set_connections (packet, connections);
+  cpu_num = get_nprocs ();
+  cpu_load = g_malloc0 (sizeof (gfloat) * cpu_num);
+  elements = g_hash_table_new (g_str_hash, g_str_equal);
+  connections = g_hash_table_new (g_str_hash, g_str_equal);
 
-	pthread_t thread;
-	pthread_create(&thread, NULL, curses_loop, packet);
-	pthread_detach(thread);
+  packet = g_malloc0 (sizeof (Packet));
+  packet_set_cpu_num (packet, cpu_num);
+  packet_set_cpu_load (packet, cpu_load);
+  packet_set_elements (packet, elements);
+  packet_set_connections (packet, connections);
 
-	return TRUE;
+  pthread_t thread;
+  pthread_create (&thread, NULL, curses_loop, packet);
+  pthread_detach (thread);
+
+  return TRUE;
 }
 
-void 
-update_cpuusage_event (guint32 cpunum, gfloat * cpuload) 
+void
+update_cpuusage_event (guint32 cpunum, gfloat * cpuload)
 {
-	gint cpu_num = packet->cpu_num;
-	gfloat * cpu_load = packet->cpu_load;
+  gint cpu_num = packet->cpu_num;
+  gfloat *cpu_load = packet->cpu_load;
 
-	memcpy (cpu_load, cpuload, cpu_num * sizeof(gfloat));
+  memcpy (cpu_load, cpuload, cpu_num * sizeof (gfloat));
 }
 
 void
 update_queue_level_event (const gchar * elementname, guint size_buffer,
-		guint max_size_buffer)
+    guint max_size_buffer)
 {
-	GHashTable * elements = packet->elements;
-	ElementUnit * pElement;
-	
-	pElement = g_hash_table_lookup(elements, elementname);
-	g_return_if_fail(pElement);
-	pElement->queue_level = size_buffer;
-	pElement->max_queue_level = max_size_buffer;
+  GHashTable *elements = packet->elements;
+  ElementUnit *pElement;
+
+  pElement = g_hash_table_lookup (elements, elementname);
+  g_return_if_fail (pElement);
+  pElement->queue_level = size_buffer;
+  pElement->max_queue_level = max_size_buffer;
 }
 
 void
-element_push_buffer_pre (gchar * elementname, gchar * padname, guint64 ts, guint64 buffer_size) 
+element_push_buffer_pre (gchar * elementname, gchar * padname, guint64 ts,
+    guint64 buffer_size)
 {
-	//printf("[%ld]%s-%s pre\n", ts, elementname, padname);
-	GHashTable * elements = packet->elements;
-	ElementUnit * pElement, * pPeerElement;
-	PadUnit * pPad, * pPeerPad;
-	gdouble datarate;
-	guint length;
-	guint64 * pTime;
+  //printf("[%ld]%s-%s pre\n", ts, elementname, padname);
+  GHashTable *elements = packet->elements;
+  ElementUnit *pElement, *pPeerElement;
+  PadUnit *pPad, *pPeerPad;
+  gdouble datarate;
+  guint length;
+  guint64 *pTime;
 
-	pElement = g_hash_table_lookup (elements, elementname);
-	g_return_if_fail (pElement);
-	pPad = g_hash_table_lookup (pElement->pad, padname);
-	g_return_if_fail (pPad);
-	pPeerPad = pad_unit_peer(elements, pPad);
-	g_return_if_fail (pPeerPad);
-	pPeerElement = pad_unit_parent(elements, pPeerPad);
-	g_return_if_fail (pPeerElement);
+  pElement = g_hash_table_lookup (elements, elementname);
+  g_return_if_fail (pElement);
+  pPad = g_hash_table_lookup (pElement->pad, padname);
+  g_return_if_fail (pPad);
+  pPeerPad = pad_unit_peer (elements, pPad);
+  g_return_if_fail (pPeerPad);
+  pPeerElement = pad_unit_parent (elements, pPeerPad);
+  g_return_if_fail (pPeerElement);
 
-	if(pPeerElement->is_filter) {
-		pPeerElement->time = ts;
-	}	
-	
-	if(pElement->is_filter) {
-		if(ts - pElement->time > 0) {
-			avg_update_value(pElement->proctime, ts - pElement->time);
-		}
-	}
+  if (pPeerElement->is_filter) {
+    pPeerElement->time = ts;
+  }
 
-	length = g_queue_get_length(pPad->time_log);
+  if (pElement->is_filter) {
+    if (ts - pElement->time > 0) {
+      avg_update_value (pElement->proctime, ts - pElement->time);
+    }
+  }
 
-	if(length == 0) {
-		pTime = g_malloc(sizeof(gdouble));
-		*pTime = ts;
-	}
-	else {
-		if(length > 10) {
-			pTime = (guint64 *) g_queue_pop_tail(pPad->time_log);
-		}
-		else {
-			pTime = (guint64 *) g_queue_peek_tail(pPad->time_log);
-		}
-		
-		datarate = 1e9 * length /  (ts - *pTime);
-		pPad->datarate = datarate;
-		pPeerPad->datarate = datarate;
-		
-		pTime = g_malloc(sizeof(gdouble));
-		*pTime = ts;
-	}
-	g_queue_push_head(pPad->time_log, pTime);
+  length = g_queue_get_length (pPad->time_log);
 
-	avg_update_value(pPad->buffer_size, buffer_size);
-	avg_update_value(pPeerPad->buffer_size, buffer_size);
+  if (length == 0) {
+    pTime = g_malloc (sizeof (gdouble));
+    *pTime = ts;
+  } else {
+    if (length > 10) {
+      pTime = (guint64 *) g_queue_pop_tail (pPad->time_log);
+    } else {
+      pTime = (guint64 *) g_queue_peek_tail (pPad->time_log);
+    }
+
+    datarate = 1e9 * length / (ts - *pTime);
+    pPad->datarate = datarate;
+    pPeerPad->datarate = datarate;
+
+    pTime = g_malloc (sizeof (gdouble));
+    *pTime = ts;
+  }
+  g_queue_push_head (pPad->time_log, pTime);
+
+  avg_update_value (pPad->buffer_size, buffer_size);
+  avg_update_value (pPeerPad->buffer_size, buffer_size);
 }
 
 void
 element_push_buffer_post (gchar * elementname, gchar * padname, guint64 ts)
 {
-	//printf("[%ld]%s-%s post\n", ts, elementname, padname);
+  //printf("[%ld]%s-%s post\n", ts, elementname, padname);
 }
 
 void
 element_push_buffer_list_pre (gchar * elementname, gchar * padname, guint64 ts)
 {
-	//printf("[%ld]%s-%s pre list\n", ts, elementname, padname);
+  //printf("[%ld]%s-%s pre list\n", ts, elementname, padname);
 }
+
 void
 element_push_buffer_list_post (gchar * elementname, gchar * padname, guint64 ts)
 {
-	//printf("[%ld]%s-%s post list\n", ts, elementname, padname);
+  //printf("[%ld]%s-%s post list\n", ts, elementname, padname);
 }
+
 void
 element_pull_range_pre (gchar * elementname, gchar * padname, guint64 ts)
 {
-	//printf("[%ld]%s-%s pre pull\n", ts, elementname, padname);
+  //printf("[%ld]%s-%s pre pull\n", ts, elementname, padname);
 }
 
 void
 element_pull_range_post (gchar * elementname, gchar * padname, guint64 ts)
 {
-	//printf("[%ld]%s-%s post pull\n", ts, elementname, padname);
+  //printf("[%ld]%s-%s post pull\n", ts, elementname, padname);
 }
 
 
 
 void
-update_pipeline_init (GstPipeline * element) 
+update_pipeline_init (GstPipeline * element)
 {
-	add_children_recursively ((GstElement *) element, packet->elements);
+  add_children_recursively ((GstElement *) element, packet->elements);
+  if (g_getenv ("LOG_ENABLED") && !metadata_writed) {
+    g_hash_table_foreach (packet->elements, (GHFunc) generate_meta_data, NULL);
+    metadata_writed = log_idx;
+  }
 }

--- a/plugins/tracers/gstliveprofiler.h
+++ b/plugins/tracers/gstliveprofiler.h
@@ -15,6 +15,7 @@ void update_pipeline_init (GstPipeline * element);
 
 void update_proctime (ElementUnit * element, ElementUnit * peerElement,
     guint64 ts);
+void update_queue_level (ElementUnit * element);
 void update_datatrate (PadUnit * pad, PadUnit * peerPad, guint64 ts);
 void update_buffer_size (PadUnit * pad, PadUnit * peerPad, guint64 size);
 
@@ -29,5 +30,9 @@ void element_push_buffer_list_post (gchar * elementname, gchar * padname,
 void element_pull_range_pre (gchar * elementname, gchar * padname, guint64 ts);
 void element_pull_range_post (gchar * elementname, gchar * padname, guint64 ts);
 
+gboolean is_filter (GstElement * element);
+void generate_meta_data_pad (gpointer key, gpointer value, gpointer user_data);
+void generate_meta_data (gpointer key, gpointer value, gpointer user_data);
+void add_children_recursively (GstElement * element, GHashTable * table);
 
 G_BEGIN_DECLS G_END_DECLS

--- a/plugins/tracers/gstliveunit.h
+++ b/plugins/tracers/gstliveunit.h
@@ -34,12 +34,6 @@ struct _ElementUnit
 struct _PadUnit
 {
   GstElement *element;
-
-	GQueue * time_log;
-	guint64 time;
-
-	guint32 idx; // for log metadata
-
   GQueue *time_log;
   guint64 time;
 

--- a/plugins/tracers/gstliveunit.h
+++ b/plugins/tracers/gstliveunit.h
@@ -9,6 +9,7 @@ typedef struct _AvgUnit AvgUnit;
 typedef struct _ElementUnit ElementUnit;
 typedef struct _PadUnit PadUnit;
 typedef struct _ConnectionUnit ConnectionUnit;
+typedef struct _LogUnit LogUnit;
 
 struct _AvgUnit
 {
@@ -21,7 +22,9 @@ struct _ElementUnit
 {
 	GstElement * element;
 	GHashTable * pad;
-	
+
+	guint32 idx; // for log metadata
+
 	guint64 time;
 
 	AvgUnit * proctime;
@@ -37,6 +40,8 @@ struct _PadUnit
 
 	GQueue * time_log;
 	guint64 time;
+
+	guint32 idx; // for log metadata
 	
 	AvgUnit * buffer_size;
 	gdouble datarate;
@@ -47,6 +52,14 @@ struct _ConnectionUnit
 {
 	GstElement * src;
 	GstElement * dest;
+};
+
+struct _LogUnit
+{
+	guint64 proctime;
+	guint32 queue_level;
+	guint32 max_queue_level;
+	gdouble bufrate;
 };
 
 void avg_update_value (AvgUnit * unit, guint64 value);

--- a/plugins/tracers/gstliveunit.h
+++ b/plugins/tracers/gstliveunit.h
@@ -49,7 +49,7 @@ struct _LogUnit
 	guint64 proctime;
 	guint32 queue_level;
 	guint32 max_queue_level;
-	gdouble bufrate;
+	guint32 bufrate;
 };
 
 void avg_update_value (AvgUnit * unit, guint64 value);

--- a/plugins/tracers/gstliveunit.h
+++ b/plugins/tracers/gstliveunit.h
@@ -20,11 +20,11 @@ struct _ElementUnit
   GstElement *element;
   GHashTable *pad;
 
-	guint32 idx; // for log metadata
-
 	guint64 time;
 
 	AvgUnit * proctime;
+
+  guint32 elem_idx; // for log metadata
 	
 	gboolean is_filter;
 	guint32 queue_level;
@@ -36,6 +36,8 @@ struct _PadUnit
   GstElement *element;
   GQueue *time_log;
   guint64 time;
+
+  guint32 elem_idx; // for log metadata
 
   AvgUnit *buffer_size;
   gdouble datarate;

--- a/plugins/tracers/visualizeutil.c
+++ b/plugins/tracers/visualizeutil.c
@@ -1,6 +1,7 @@
 #include <ncurses.h>
 #include <string.h>
 #include <time.h>
+#include <math.h>
 
 #include "visualizeutil.h"
 #include "gstliveprofiler.h"
@@ -88,27 +89,18 @@ print_pad (gpointer key, gpointer value, gpointer user_data)
   // check value for each element is changed
   if (g_getenv ("LOG_ENABLED") && element_log) {
     char element_log_text[100];
-    char *buf = &element_log_text[0];
     int new_datarate = (int) (data->datarate * 100);
-    if (element_log[row_current - 13].bufrate != new_datarate) {
-      buf +=
-          sprintf (buf, "%d",
-          (int) (data->datarate * 100) - element_log[row_current - 13].bufrate);
-      element_log[row_current - 13].bufrate = (int) (data->datarate * 100);
-    }
+    int changed = new_datarate - element_log[row_current - 13].bufrate;
 
-    if (strlen (element_log_text) != 0) {
-      char changed_data[100];
-      // sprintf (changed_data, "p %d %s", row_current-13, element_log_text);
-
-      // mvprintw (row_offset + row_current, ELEMENT_NAME_MAX * 4 + 2,
-      // "%d", new_datarate);
-
-      // do_print_log ("log", changed_data);
+    if (changed != 0) {
+      sprintf (element_log_text, "p %d %d", row_current - 13, changed);
+      do_print_log ("log", element_log_text);
+      element_log[row_current - 13].bufrate = new_datarate;
     }
   }
-  // mvprintw (row_offset + row_current, ELEMENT_NAME_MAX * 4 + 2,
-  //     "%20.2f", data->datarate);
+
+  mvprintw (row_offset + row_current, ELEMENT_NAME_MAX * 4 + 2,
+      "%20.2f", data->datarate);
   row_current++;
 }
 

--- a/plugins/tracers/visualizeutil.c
+++ b/plugins/tracers/visualizeutil.c
@@ -113,6 +113,39 @@ print_element (gpointer key, gpointer value, gpointer user_data)
   }
   attroff (A_BOLD);
 
+  // check value for each element is changed
+  if (g_getenv ("LOG_ENABLED") && element_log) {
+
+    char element_log_text[100];
+    char *buf = &element_log_text[0];
+    if (element_log[data->elem_idx].proctime != data->proctime->value) {
+      buf +=
+          sprintf (buf, "%ld ",
+          data->proctime->value - element_log[data->elem_idx].proctime);
+      element_log[data->elem_idx].proctime = data->proctime->value;
+    } else
+      buf += sprintf (buf, ". ");
+
+    if (element_log[data->elem_idx].queue_level != data->queue_level) {
+      buf += sprintf (buf, "%d ", data->queue_level);
+      element_log[data->elem_idx].queue_level = data->queue_level;
+    } else
+      buf += sprintf (buf, ". ");
+
+    if (element_log[data->elem_idx].max_queue_level != data->max_queue_level) {
+      buf += sprintf (buf, "%d", data->max_queue_level);
+      element_log[data->elem_idx].max_queue_level = data->max_queue_level;
+    } else
+      buf += sprintf (buf, ".");
+
+    if (strcmp (element_log_text, ". . .")) {
+      char changed_data[100];
+      sprintf (changed_data, "%d %s", data->elem_idx, element_log_text);
+
+      do_print_log ("log", changed_data);
+    }
+  }
+
   mvprintw (row_offset + row_current, ELEMENT_NAME_MAX,
       "%20ld %20.3f %17d/%2d",
       data->proctime->value,

--- a/plugins/tracers/visualizeutil.c
+++ b/plugins/tracers/visualizeutil.c
@@ -85,8 +85,30 @@ print_pad (gpointer key, gpointer value, gpointer user_data)
     mvprintw (row_offset + row_current, 4, "%s", name);
   }
 
-  mvprintw (row_offset + row_current, ELEMENT_NAME_MAX * 4 + 2,
-      "%20.2f", data->datarate);
+  // check value for each element is changed
+  if (g_getenv ("LOG_ENABLED") && element_log) {
+    char element_log_text[100];
+    char *buf = &element_log_text[0];
+    int new_datarate = (int) (data->datarate * 100);
+    if (element_log[row_current - 13].bufrate != new_datarate) {
+      buf +=
+          sprintf (buf, "%d",
+          (int) (data->datarate * 100) - element_log[row_current - 13].bufrate);
+      element_log[row_current - 13].bufrate = (int) (data->datarate * 100);
+    }
+
+    if (strlen (element_log_text) != 0) {
+      char changed_data[100];
+      // sprintf (changed_data, "p %d %s", row_current-13, element_log_text);
+
+      // mvprintw (row_offset + row_current, ELEMENT_NAME_MAX * 4 + 2,
+      // "%d", new_datarate);
+
+      // do_print_log ("log", changed_data);
+    }
+  }
+  // mvprintw (row_offset + row_current, ELEMENT_NAME_MAX * 4 + 2,
+  //     "%20.2f", data->datarate);
   row_current++;
 }
 
@@ -118,29 +140,32 @@ print_element (gpointer key, gpointer value, gpointer user_data)
 
     char element_log_text[100];
     char *buf = &element_log_text[0];
-    if (element_log[data->elem_idx].proctime != data->proctime->value) {
+    if (element_log[row_current - 13].proctime != data->proctime->value) {
       buf +=
           sprintf (buf, "%ld ",
-          data->proctime->value - element_log[data->elem_idx].proctime);
-      element_log[data->elem_idx].proctime = data->proctime->value;
+          data->proctime->value - element_log[row_current - 13].proctime);
+      element_log[row_current - 13].proctime = data->proctime->value;
     } else
       buf += sprintf (buf, ". ");
 
-    if (element_log[data->elem_idx].queue_level != data->queue_level) {
+    if (element_log[row_current - 13].queue_level != data->queue_level) {
       buf += sprintf (buf, "%d ", data->queue_level);
-      element_log[data->elem_idx].queue_level = data->queue_level;
+      element_log[row_current - 13].queue_level = data->queue_level;
     } else
       buf += sprintf (buf, ". ");
 
-    if (element_log[data->elem_idx].max_queue_level != data->max_queue_level) {
+    if (element_log[row_current - 13].max_queue_level != data->max_queue_level) {
       buf += sprintf (buf, "%d", data->max_queue_level);
-      element_log[data->elem_idx].max_queue_level = data->max_queue_level;
+      element_log[row_current - 13].max_queue_level = data->max_queue_level;
     } else
       buf += sprintf (buf, ".");
 
+    // mvprintw (row_offset + row_current, ELEMENT_NAME_MAX,
+    //   "%10d %10d", row_current, data->elem_idx);
+
     if (strcmp (element_log_text, ". . .")) {
       char changed_data[100];
-      sprintf (changed_data, "%d %s", data->elem_idx, element_log_text);
+      sprintf (changed_data, "%d %s", row_current - 13, element_log_text);
 
       do_print_log ("log", changed_data);
     }


### PR DESCRIPTION
Can enable logging with add environment variable LOG_ENABLED=TRUE when you run.

Experiment
---
Run and log gst-launch-object-detection-tflite.sh for 1 minute
- gst-shark logging file : 435 kB
- LiveProfiler logging file : 186 kB

Logging file size was reduced by 60%.