### PR TITLE
Proctime calculation on queue

### DIFF
--- a/plugins/tracers/gstlive.c
+++ b/plugins/tracers/gstlive.c
@@ -132,8 +132,7 @@ do_pad_push_pre (GstTracer * self, guint64 ts, GstPad * pad, GstBuffer * buffer)
     do_print_log (file_name, text);
   }
 
-  element_push_buffer_pre (element_name, pad_name, ts,
-      gst_buffer_get_size (buffer));
+  element_push_buffer_pre (element_name, pad_name, ts, buffer);
 }
 
 static void

--- a/plugins/tracers/gstliveprofiler.c
+++ b/plugins/tracers/gstliveprofiler.c
@@ -186,7 +186,7 @@ update_queue_level (ElementUnit * element)
 
 void
 element_push_buffer_pre (gchar * elementname, gchar * padname, guint64 ts,
-    guint64 buffer_size)
+    GstBuffer * buffer)
 {
   GHashTable *elements = packet->elements;
   ElementUnit *pElement, *pPeerElement;
@@ -209,7 +209,7 @@ element_push_buffer_pre (gchar * elementname, gchar * padname, guint64 ts,
 
   update_proctime (pElement, pPeerElement, ts);
   update_datatrate (pPad, pPeerPad, ts);
-  update_buffer_size (pPad, pPeerPad, buffer_size);
+  update_buffer_size (pPad, pPeerPad, gst_buffer_get_size (buffer));
   update_queue_level (pElement);
 }
 

--- a/plugins/tracers/gstliveprofiler.h
+++ b/plugins/tracers/gstliveprofiler.h
@@ -18,7 +18,7 @@ void update_datatrate (PadUnit * pad, PadUnit * peerPad, guint64 ts);
 void update_buffer_size (PadUnit * pad, PadUnit * peerPad, guint64 size);
 
 void element_push_buffer_pre (gchar * elementname, gchar * padname, guint64 ts,
-    guint64 buffer_size);
+    GstBuffer * buffer);
 void element_push_buffer_post (gchar * elementname, gchar * padname,
     guint64 ts);
 void element_push_buffer_list_pre (gchar * elementname, gchar * padname,

--- a/plugins/tracers/gstliveprofiler.h
+++ b/plugins/tracers/gstliveprofiler.h
@@ -12,7 +12,7 @@ void update_pipeline_init (GstPipeline * element);
 void update_pipeline_finalize (GstPipeline * element);
 
 void update_proctime (ElementUnit * element, ElementUnit * peerElement,
-    guint64 ts);
+    guint64 ts, guint64 offset);
 void update_queue_level (ElementUnit * element);
 void update_datatrate (PadUnit * pad, PadUnit * peerPad, guint64 ts);
 void update_buffer_size (PadUnit * pad, PadUnit * peerPad, guint64 size);

--- a/plugins/tracers/gstliveunit.c
+++ b/plugins/tracers/gstliveunit.c
@@ -78,6 +78,7 @@ element_unit_new (GstElement * element)
       (GDestroyNotify) pad_unit_free);
 
   e->time = 0;
+  e->time_log = g_queue_new ();
 
   e->proctime = avg_unit_new ();
   e->queue_level = 0;
@@ -148,6 +149,8 @@ pad_unit_parent (GHashTable * elements, PadUnit * target)
   return g_hash_table_lookup (elements,
       GST_OBJECT_NAME (GST_OBJECT_PARENT (target->element)));
 }
+
+
 
 /******************************************************
  * Packet-related new/free functions                  *

--- a/plugins/tracers/gstliveunit.h
+++ b/plugins/tracers/gstliveunit.h
@@ -4,6 +4,7 @@
 #include <gst/gst.h>
 
 G_BEGIN_DECLS typedef struct _AvgUnit AvgUnit;
+typedef struct _BufferUnit BufferUnit;
 typedef struct _ElementUnit ElementUnit;
 typedef struct _PadUnit PadUnit;
 typedef struct _LogUnit LogUnit;
@@ -16,12 +17,19 @@ struct _AvgUnit
   gdouble avg;
 };
 
+struct _BufferUnit
+{
+  guint64 ts;
+  guint64 offset;
+};
+
 struct _ElementUnit
 {
   GstElement *element;
   GHashTable *pad;
 
   guint64 time;
+  GQueue *time_log;
 
   AvgUnit *proctime;
   guint32 queue_level;


### PR DESCRIPTION
Now proctime checked by comparing in/out buffer offset
Parameter fixed on some functions
* update_proctime now needs additional parameter: **guint64 offset**
* element_push_buffer_pre now uses parameter **GstBuffer * buffer**, instead of **guint64 buffer_size**